### PR TITLE
Add instructions and cost to modal, broke tags in Recipe class

### DIFF
--- a/src/Recipe.js
+++ b/src/Recipe.js
@@ -5,15 +5,18 @@ class Recipe {
     this.image = recipe.image;
     this.ingredients = recipe.ingredients;
     this.instructions = recipe.instructions;
-    this.tags = recipe.tags;
-  }
-
-  checkName = (recipe) => {
-    return typeof recipe === 'string' ? recipe : JSON.stringify(recipe);
+    this.tags = this.checkTags(recipe);
   }
 
   checkNumber = (recipe) => {
     return typeof recipe === 'number' ? recipe : Date.now();
+  }
+
+  checkName = (recipe) => {
+    if (!recipe) {
+      return "Recipe";
+    }
+    return typeof recipe === 'string' ? recipe : JSON.stringify(recipe);
   }
 
   getInstructions = () => {
@@ -21,6 +24,15 @@ class Recipe {
       return directions += `${instruction.number}. ${instruction.instruction}<br>`;
     }, "");
   }
+
+  checkTags = (recipe) => {
+    if (!Array.isArray(recipe) || recipe.length === 0) {
+      return ["miscellaneous"];
+    }
+    else {
+      return recipe.tags;
+    }
+  } 
 
   getRecipeCost = (ingredientsList) => {
     return this.ingredients.reduce((sum, recipeIngredient) => {

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -1,3 +1,5 @@
+// const Recipe = require("./Recipe");
+
 let recipeCardSection = document.querySelector(".recipe-cards-parent");
 let userPantryBtn = document.getElementById("user-pantry-btn");
 let addToFavesBtn = document.querySelector(".add-favorite-recipe-btn");
@@ -73,6 +75,7 @@ const loadHandler = () => {
 }
 
 // Pantry Modal //
+
 const viewPantryList = () => {
   openPantryInfo();
 }
@@ -95,8 +98,8 @@ userPantryBtn.addEventListener("click", viewPantryList);
 // Buttons on Recipe Cards //
 
 // const addRecipeToFaves = (event) => {
-  // let recipeId = event.path.find(e => e.id).id;
-  // let recipe = recipeData.find(recipe => recipe.id === Number(recipeId));
+// let recipeId = event.path.find(e => e.id).id;
+// let recipe = recipeData.find(recipe => recipe.id === Number(recipeId));
 //   currentUser.addFavoriteRecipe(recipe); 
 // } /// not functional 
 
@@ -136,9 +139,10 @@ const openAllRecipeInfo = () => {
   allRecipeInfo.innerHTML = "";
   allRecipeInfo.style.display = "inline";
   let recipeId = event.path.find(e => e.id).id;
-  let recipe = recipeData.find(recipe => recipe.id === Number(recipeId));
+  let recipeObj = recipeData.find(recipe => recipe.id === Number(recipeId));
+  let recipe =  new Recipe(recipeObj); 
   let recipeIngredients = recipe.ingredients;
-  generateRecipeDetails(recipe, makeIngredientsReadable(recipeIngredients));
+  generateRecipeDetails(recipe, makeIngredientsReadable(recipeIngredients), getRecipeInstructions(recipe), getNeededIngredientsList(recipe, ingredientsData));
 };
 
 const getIngredientName = (recipeIngredient) => {
@@ -152,7 +156,17 @@ const makeIngredientsReadable = (recipeIngredients) => {
   }).join(", ");
 }
 
-const generateRecipeDetails = (recipe, ingredients) => {
+const getRecipeInstructions = (recipe) => {
+  return recipe.getInstructions();
+}
+
+const getNeededIngredientsList = (recipe, ingredientsList) => {
+  return currentPantry.createGroceryList(recipe, ingredientsList).map(ingredient => {
+    return `${capitalize(ingredient.name)} $${Math.round(ingredient.cost)}`;
+  }).join(", ");
+}
+
+const generateRecipeDetails = (recipe, ingredients, instructions, neededIngredients) => {
   let fullRecipeInfo = document.querySelector(".recipe-instructions");
   let recipeTitle = `
       <button id="exit-btn"><img src="../assets/close.svg" class="close-icon" alt="Close instructions"></button>
@@ -162,11 +176,12 @@ const generateRecipeDetails = (recipe, ingredients) => {
       <h4>Ingredients</h4>
       <article class="card-ingredients-list">${ingredients}</article>
       <h4>Instructions</h4>
-      <article>Boil water</article>
+      <article>${instructions}</article>
       <h4>Cost</h4>
-      <article>Total Recipe Cost:   - What's In Your Pantry :  =  $10!</article>`
+      <article>To make this recipe, you need to buy: </br> ${neededIngredients}.</article>`
   fullRecipeInfo.insertAdjacentHTML("beforeend", recipeTitle);
 }
+
 
 // const closeRecipe = () => {
 //   console.log(test);

--- a/test/recipe-test.js
+++ b/test/recipe-test.js
@@ -103,8 +103,17 @@ describe('Recipe', function() {
 
   it('should have tags', function() {
     expect(recipe.tags).to.be.an('array');
-    expect(recipe.tags.length).to.equal(2)
+    expect(recipe.tags.length).to.equal(2);
   });
+
+  it.only('can have default tags if no tags are given', function() {
+    let testRecipeTags = 
+
+    expect(recipe.tags).to.be.an('array');
+    
+
+    expect(recipe.tags).to.be.deep.equal(["miscellaneous"]);
+  })
 
   it('should return recipe instructions', function() {
     expect(recipe.getInstructions()).to.equal('1. Boil water<br>')


### PR DESCRIPTION
### Type of change made:
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Styling- no new features

### Detailed Description
We can see cost of recipe and the instructions. However, there is an issue with matching a tag if the tag is undefined.

### Why is this change required? What problem does it solve?
User can now see the instructions and total cost on the recipe modal. 

### Were there any challenges that arose while implementing this feature? If so, how were the addressed?
Yes, we have a bug in the recipe class file

### Files modified:
- [ ] index.html
- [ ] styles.css
- [X] main.js
- [X] Other files: recipe.js
